### PR TITLE
Wireless protocol wording expansion

### DIFF
--- a/ruleset.md
+++ b/ruleset.md
@@ -57,7 +57,6 @@ OR
 ## Communications
 
 All communication between the controller and console must be either via wires or a wireless protocol that prevents interference.
-If a wireless protocol is used, the controller must ensure that only a 1:1 mapping between the controller and receiver is possible. For example, it must not be possible to connect two controllers to one receiver or one controller to two receivers. This mapping must be visually distinguishable, such as through matching colors on an LED on both the controller and receiver. 
 
 ## Input Layout
 

--- a/ruleset.md
+++ b/ruleset.md
@@ -57,6 +57,7 @@ OR
 ## Communications
 
 All communication between the controller and console must be either via wires or a wireless protocol that prevents interference.
+If a wireless protocol is used, the controller must ensure that only a 1:1 mapping between the controller and receiver is possible. For example, it must not be possible to connect two controllers to one receiver or one controller to two receivers. This mapping must be visually distinguishable, such as through matching colors on an LED on both the controller and receiver. 
 
 ## Input Layout
 

--- a/ruleset.md
+++ b/ruleset.md
@@ -57,6 +57,7 @@ OR
 ## Communications
 
 All communication between the controller and console must be either via wires or a wireless protocol that prevents interference.
+If a wireless protocol is used, the controller must ensure that only a 1:1 mapping between the controller and receiver is possible. For example, it must not be possible to connect two controllers to one receiver or one controller to two receivers. This mapping must be visually distinguishable, such as through matching colors on an LED on both the controller and receiver.
 
 ## Input Layout
 

--- a/ruleset.md
+++ b/ruleset.md
@@ -24,7 +24,7 @@ Digitized Half-Range Analog Input (DHRAI): an intermediate digital value activat
 
 Full-Range Analog Input: any Analog Input device with a default output not at either end of its range
 
-Nonreturning Analog Input: any Analog Input device that does not automatically return to a default output (ex. physical volume slider)
+Non-returning Analog Input: any Analog Input device that does not automatically return to a default output (ex. physical volume slider)
 
 Two-Axis Analog Input: any Analog Input device which consists of two independently-controllable Full-Range Analog Inputs that share an Actuator (ex. analog stick)
 
@@ -47,7 +47,7 @@ Influence: to be one of the inputs used by the controller to determine the state
 TOs may inspect any controller at any time.
 If a player suspects their opponent's controller is not abiding by these rules, they may request a controller inspection by TOs.
 The TO is not required to abide by this request.
-If TOs are unable to determine that a controller is in full compliance, that controller may be banned at the TOs' sole discretion. 
+If TOs are unable to determine that a controller is in full compliance, that controller may be banned at the TOs' sole discretion.
 If a game or match cannot be played out in full due to a controller malfunction which cannot be fixed in a timely manner, and the player using the controller does not have a replacement controller readily available, the player may be disqualified at the sole discretion of TOs.
 
 **All filter software source code shall be provided to the ruleset team in a non-obfuscated manner for compliance analysis.**
@@ -137,7 +137,7 @@ Coordinate Snapping/Accessibility Restriction: The region of linearized Input co
 This restriction exists to prevent coordinate remapping that makes it easy to pinpoint specific values or that prevents you from ever outputting certain coordinates.
 
 EXCEPTION: Output coordinates that are within 3 units of or entirely contained in the Melee Deadzone may have linearized Input coordinates that are more than 30% smaller bounding box and/or 50% smaller in area than the corresponding Output coordinates.
-This exception does not allow a violation of radial remapping distance restrions.
+This exception does not allow a violation of radial remapping distance restrictions.
 This exception is to allow "rescuing" of heavily worn notches that were originally intended to keep the stick out of the the deadzone.
 This is not intended to allow, for example, an across-the-board remapping of deadzone values near Y = +0.2875 to be mapped to Y = +0.2875 to make uptilts easier.
 
@@ -179,7 +179,7 @@ Permitted filters include but are not limited to:
 6. "energy-state tracking low-pass filter" (**may need more rule tweaking once we know more about how it's implemented**)
 
 Prohibited filters include but are not limited to:
-1. Timer-based pode emulation
+1. Timer-based PODE emulation
 2. Timer-based dashback out of crouch enhancement
 3. Timer-based empty pivot enhancement
 4. Angle- and timer-based ledgedash enhancement
@@ -253,7 +253,7 @@ The following C-Stick coordinates must not be accessible using Digital Inputs:
   * X = ±0.8000: Popo Smash
   * Y = ±0.6625: Popo Smash
   * X = ±0.7000: Popo Roll EXCEPT FOR Y = ±0.7000
-  * X = -0.7000: Popo Spotdodge EXCEPT FOR X = ±0.7000 
+  * X = -0.7000: Popo Spotdodge EXCEPT FOR X = ±0.7000
   * Y = +0.6625: Popo Jump out of Shield
   * X = +0.5250, Y = +0.6250: two different aerials
   * X = -0.4375, Y = +0.5250: two different aerials
@@ -331,4 +331,3 @@ The Analog Trigger Output value must default to 0.
 The Analog Trigger Output value when influenced by Digital Inputs must not be from 43 to 48 inclusive.
 
 If a Digital Input used to influence an Analog Trigger Output is part of a Combined Analog Digital Input, the Analog Input part of the CADI must not influence any Outputs.
-


### PR DESCRIPTION
I had a discussion with Wireless PhobGCC Dev glazed#3742 back a few months and discussed what wireless comms in competitive play should look like. The goal is to restrict Wavebirds while allowing for third party wireless controllers that can ensure a 1:1 mapping between TX and RX, not allowing for 2:1 or 1:2. What we found important is that this should be easily distinguishable, perhaps through the use of an RGB LED on the controller and the receiver which must match. 

You can reword it better if you think it can be improved, but this is the idea. 
(Yes I initially committed to the wrong branch)